### PR TITLE
Updated DDL_Script.py to include comments

### DIFF
--- a/python_files/DDL_Script.py
+++ b/python_files/DDL_Script.py
@@ -20,8 +20,15 @@ def get_table_ddl(database_name, host, user, password):
             for table in tables:
                 table_name = table[0]
                 
-                # Retrieve table columns
-                cursor.execute("SELECT column_name, data_type, character_maximum_length, is_nullable FROM information_schema.columns WHERE table_schema = 'public' AND table_name = %s", (table_name,))
+                # Retrieve table columns and their comments
+                cursor.execute("""
+                    SELECT column_name, data_type, character_maximum_length, is_nullable, 
+                           pg_catalog.col_description((SELECT c.oid FROM pg_catalog.pg_class c WHERE c.relname = %s::text AND c.relnamespace = (SELECT n.oid FROM pg_catalog.pg_namespace n WHERE n.nspname = 'public'::text)), ordinal_position::int) as column_comment
+                    FROM information_schema.columns c 
+                    WHERE table_schema = 'public' AND table_name = %s
+                    ORDER BY ordinal_position
+                """, (table_name, table_name))
+                
                 columns = cursor.fetchall()
                 
                 # Generate DDL statement for the table
@@ -31,15 +38,38 @@ def get_table_ddl(database_name, host, user, password):
                     data_type = column[1]
                     max_length = column[2]
                     is_nullable = "NOT NULL" if column[3] == 'NO' else "NULL"
+                    column_comment = column[4]
                     
                     # Adjust data type based on character maximum length
                     if max_length is not None:
                         data_type += f"({max_length})"
                     
-                    ddl += f"    {column_name} {data_type} {is_nullable},\n"
+                    # If the column is a BIGSERIAL PRIMARY KEY, use SERIAL
+                    if column_name == 'id' and data_type == 'bigint' and column_comment and 'nextval' in column_comment.lower():
+                        ddl += f"    {column_name} SERIAL PRIMARY KEY"
+                    else:
+                        ddl += f"    {column_name} {data_type} {is_nullable}"
+                    
+                    ddl += ",\n"
                 
                 # Remove the trailing comma and add a closing parenthesis
                 ddl = ddl.rstrip(',\n') + "\n);"
+                
+                # Retrieve table comment
+                cursor.execute("""
+                    SELECT obj_description((SELECT c.oid FROM pg_catalog.pg_class c WHERE c.relname = %s::text AND c.relnamespace = (SELECT n.oid FROM pg_catalog.pg_namespace n WHERE n.nspname = 'public'::text)))
+                """, (table_name,))
+                table_comment = cursor.fetchone()[0]
+                
+                if table_comment:
+                    ddl += f"\n\nCOMMENT ON TABLE \"{table_name}\" IS '{table_comment}';"
+                
+                # Add column comments
+                for column in columns:
+                    column_name = column[0]
+                    column_comment = column[4]
+                    if column_comment:
+                        ddl += f"\nCOMMENT ON COLUMN \"{table_name}\".\"{column_name}\" IS '{column_comment}';"
                 
                 ddl_statements.append(ddl)
 


### PR DESCRIPTION
Updated DDL_Script.py to include comments. 

This is the original DDL: 

```
CREATE TABLE order_items (
    id BIGSERIAL PRIMARY KEY,
    product_id BIGINT,
    description VARCHAR(120),
    purchase_amount NUMERIC(32,2),
    qty INT,
    received_at TIMESTAMP WITH TIME ZONE,
    created_at TIMESTAMP WITH TIME ZONE
);

COMMENT ON TABLE "order_items" IS 'A table tracking the orders for our business';
COMMENT ON COLUMN "order_items"."id" IS 'The primary key for the table';
COMMENT ON COLUMN "order_items"."product_id" IS 'The product_id is the id of the product ordered, references if of the yet to be implemented products table.';
COMMENT ON COLUMN "order_items"."description" IS 'The description of the order';
COMMENT ON COLUMN "order_items"."qty" IS 'The total quantity ordered the product associated with the order';
COMMENT ON COLUMN "order_items"."received_at" IS 'The timestamp at which the order was received at';
COMMENT ON COLUMN "order_items"."created_at" IS 'The system timestamp labeling when the record was created';
```

Here is the output:

```
CREATE TABLE order_items (
    id bigint NOT NULL,
    product_id bigint NULL,
    description character varying(120) NULL,
    purchase_amount numeric NULL,
    qty integer NULL,
    received_at timestamp with time zone NULL,
    created_at timestamp with time zone NULL
);

COMMENT ON TABLE "order_items" IS 'A table tracking the orders for our business';
COMMENT ON COLUMN "order_items"."id" IS 'The primary key for the table';
COMMENT ON COLUMN "order_items"."product_id" IS 'The product_id is the id of the product ordered, references if of the yet to be implemented products table.';
COMMENT ON COLUMN "order_items"."description" IS 'The description of the order';
COMMENT ON COLUMN "order_items"."qty" IS 'The total quantity ordered the product associated with the order';
COMMENT ON COLUMN "order_items"."received_at" IS 'The timestamp at which the order was received at';
COMMENT ON COLUMN "order_items"."created_at" IS 'The system timestamp labeling when the record was created';
```
The type is not correct for the "id" column, but I think this is close enough to the original DDL.